### PR TITLE
🔒 [security fix] Fix hardcoded Device ID in Indomaret Scraper

### DIFF
--- a/src/indoscraping/scraper/retail/indomaret/index.mjs
+++ b/src/indoscraping/scraper/retail/indomaret/index.mjs
@@ -1,4 +1,5 @@
 import { writeFile } from 'fs/promises';
+import { randomUUID } from 'node:crypto';
 
 const BASE_URL = "https://ap-mc.klikindomaret.com/assets-klikidmgroceries/api/get/catalog-xpress/api/webapp";
 
@@ -10,10 +11,17 @@ const STORE_CONFIG = {
   districtId: 141100100
 };
 
-const HEADERS = {
+export const getHeaders = () => ({
   "accept": "application/json, text/plain, */*",
   "accept-language": "en-US,en;q=0.9",
-  "apps": "{\"app_version\":\"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36\",\"device_class\":\"browser|browser\",\"device_family\":\"none\",\"device_id\":\"e97a1210-e2aa-4908-9ddd-12d4ac58afa6\",\"os_name\":\"Linux\",\"os_version\":\"x86_64\"}",
+  "apps": JSON.stringify({
+    "app_version": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
+    "device_class": "browser|browser",
+    "device_family": "none",
+    "device_id": randomUUID(),
+    "os_name": "Linux",
+    "os_version": "x86_64"
+  }),
   "page": "unpage",
   "priority": "u=1, i",
   "sec-ch-ua": "\"Not)A;Brand\";v=\"8\", \"Chromium\";v=\"138\", \"Google Chrome\";v=\"138\"",
@@ -22,9 +30,9 @@ const HEADERS = {
   "sec-fetch-dest": "empty",
   "sec-fetch-mode": "cors",
   "sec-fetch-site": "same-site",
-  "x-correlation-id": "ce59e39f-5b13-4b89-a501-06dd911d67ac",
+  "x-correlation-id": randomUUID(),
   "Referer": "https://www.klikindomaret.com/"
-};
+});
 
 function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -35,7 +43,7 @@ async function fetchCategories() {
   const url = `${BASE_URL}/category/meta?${params}`;
   
   await delay(1000); // Add delay
-  const response = await fetch(url, { headers: HEADERS });
+  const response = await fetch(url, { headers: getHeaders() });
   
   const text = await response.text();
   console.log('Response status:', response.status);
@@ -64,7 +72,7 @@ async function getProducts(page, metaCategories, categories, subCategories) {
   const url = `${BASE_URL}/search/result?${params}`;
   console.log('Fetching:', Object.fromEntries(params));
   
-  const response = await fetch(url, { headers: HEADERS });
+  const response = await fetch(url, { headers: getHeaders() });
   const data = await response.json();
   
   return data.data;
@@ -139,4 +147,7 @@ async function main() {
   }
 }
 
-main();
+import { fileURLToPath } from 'node:url';
+if (process.argv[1] && fileURLToPath(import.meta.url).endsWith(process.argv[1])) {
+  main();
+}

--- a/src/indoscraping/scraper/retail/indomaret/verify_fix.mjs
+++ b/src/indoscraping/scraper/retail/indomaret/verify_fix.mjs
@@ -1,0 +1,40 @@
+import { getHeaders } from './index.mjs';
+import assert from 'node:assert';
+
+function verifyDynamicHeaders() {
+  console.log('Verifying dynamic header generation...');
+
+  const headers1 = getHeaders();
+  const headers2 = getHeaders();
+
+  const apps1 = JSON.parse(headers1.apps);
+  const apps2 = JSON.parse(headers2.apps);
+
+  const deviceId1 = apps1.device_id;
+  const deviceId2 = apps2.device_id;
+
+  const correlationId1 = headers1['x-correlation-id'];
+  const correlationId2 = headers2['x-correlation-id'];
+
+  console.log('Run 1 Device ID:', deviceId1);
+  console.log('Run 2 Device ID:', deviceId2);
+  console.log('Run 1 Correlation ID:', correlationId1);
+  console.log('Run 2 Correlation ID:', correlationId2);
+
+  assert.notStrictEqual(deviceId1, deviceId2, 'Device IDs should be different');
+  assert.notStrictEqual(correlationId1, correlationId2, 'Correlation IDs should be different');
+
+  // Also verify they are valid UUIDs (basic check)
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  assert.ok(uuidRegex.test(deviceId1), 'Device ID 1 is not a valid UUID');
+  assert.ok(uuidRegex.test(correlationId1), 'Correlation ID 1 is not a valid UUID');
+
+  console.log('✅ Verification successful: Headers are dynamically generated and use valid UUIDs.');
+}
+
+try {
+  verifyDynamicHeaders();
+} catch (error) {
+  console.error('❌ Verification failed:', error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
🎯 **What:** The Indomaret scraper used a hardcoded `device_id` in its HTTP headers. This fix replaces the hardcoded value with a dynamically generated UUID for each request. It also addresses a hardcoded `x-correlation-id`.

⚠️ **Risk:** Hardcoded device IDs can lead to easy fingerprinting and blocking of the scraper by the target service. It can also potentially link different scraping sessions to the same "device," which might be undesirable for privacy or security reasons.

🛡️ **Solution:** 
- Imported `randomUUID` from `node:crypto`.
- Refactored the headers into a function `getHeaders()` that generates new UUIDs upon each invocation.
- Updated all `fetch` call sites to use `getHeaders()`.
- Verified the fix with a new script `verify_fix.mjs` that confirms the generation of unique, valid UUIDs for these fields.

---
*PR created automatically by Jules for task [15943507385027675909](https://jules.google.com/task/15943507385027675909) started by @nichsedge*