### PR TITLE
🔒 [security fix] Add timeout to HTTP requests in CNBC Indonesia scraper

### DIFF
--- a/src/indoscraping/scraper/news/cnbcindonesia.py
+++ b/src/indoscraping/scraper/news/cnbcindonesia.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 BASE_URL = "https://www.cnbcindonesia.com"
 INDEX_URL = f"{BASE_URL}/indeks"
+DEFAULT_TIMEOUT = 30
 
 HEADERS = {
     "User-Agent": ua.random
@@ -35,7 +36,7 @@ def get_categories():
     start_time = time.time()
     
     try:
-        res = requests.get(INDEX_URL, headers=HEADERS)
+        res = requests.get(INDEX_URL, headers=HEADERS, timeout=DEFAULT_TIMEOUT)
         res.raise_for_status()
         logger.debug(f"Categories page response status: {res.status_code}")
         
@@ -93,7 +94,7 @@ def get_articles_for_category(category, date_str):
             logger.debug(f"Fetching page {page} for category {category['name']}: {url}")
             
             try:
-                res = requests.get(url, headers=HEADERS)
+                res = requests.get(url, headers=HEADERS, timeout=DEFAULT_TIMEOUT)
                 res.raise_for_status()
                 
                 soup = BeautifulSoup(res.text, "html.parser")
@@ -137,7 +138,7 @@ def scrape_article(url):
     start_time = time.time()
     
     try:
-        response = requests.get(url, headers=HEADERS)
+        response = requests.get(url, headers=HEADERS, timeout=DEFAULT_TIMEOUT)
         response.raise_for_status()
         logger.debug(f"Article response status: {response.status_code}")
         

--- a/tests/test_cnbc_timeout.py
+++ b/tests/test_cnbc_timeout.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+
+# Add src to sys.path to import the scraper
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from indoscraping.scraper.news.cnbcindonesia import get_categories, get_articles_for_category, scrape_article, DEFAULT_TIMEOUT
+
+class TestCNBCTimeout(unittest.TestCase):
+
+    @patch('requests.get')
+    def test_get_categories_timeout(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = '<html><select onchange="articleKanalHandle(this)"></select></html>'
+        mock_get.return_value = mock_response
+
+        # We need to mock BeautifulSoup as well because it's used inside get_categories
+        with patch('indoscraping.scraper.news.cnbcindonesia.BeautifulSoup') as mock_bs:
+            get_categories()
+
+        # Verify that requests.get was called with the DEFAULT_TIMEOUT
+        mock_get.assert_called_with(unittest.mock.ANY, headers=unittest.mock.ANY, timeout=DEFAULT_TIMEOUT)
+
+    @patch('requests.get')
+    def test_get_articles_for_category_timeout(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = '<html><article><a></a></article></html>'
+        mock_response_empty = MagicMock()
+        mock_response_empty.status_code = 200
+        mock_response_empty.text = '<html></html>'
+
+        mock_get.side_effect = [mock_response, mock_response_empty]
+
+        category = {'name': 'News', 'slug': 'news', 'id': '1'}
+        with patch('indoscraping.scraper.news.cnbcindonesia.BeautifulSoup') as mock_bs:
+            mock_soup = MagicMock()
+            mock_bs.return_value = mock_soup
+            mock_soup.select.side_effect = [[MagicMock()], []]
+            get_articles_for_category(category, '2023/01/01')
+
+        # Verify that requests.get was called with the DEFAULT_TIMEOUT
+        mock_get.assert_called_with(unittest.mock.ANY, headers=unittest.mock.ANY, timeout=DEFAULT_TIMEOUT)
+
+    @patch('requests.get')
+    def test_scrape_article_timeout(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = '<html><h1>Title</h1></html>'
+        mock_get.return_value = mock_response
+
+        with patch('indoscraping.scraper.news.cnbcindonesia.BeautifulSoup') as mock_bs:
+            scrape_article('http://example.com/article')
+
+        # Verify that requests.get was called with the DEFAULT_TIMEOUT
+        mock_get.assert_called_with('http://example.com/article', headers=unittest.mock.ANY, timeout=DEFAULT_TIMEOUT)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the missing timeout in HTTP requests within the CNBC Indonesia news scraper.
⚠️ **Risk:** The potential impact if left unfixed is that the scraper could hang indefinitely if the remote server or network connection is unresponsive, which could lead to resource exhaustion and block other processes.
🛡️ **Solution:** The fix addresses the vulnerability by defining a `DEFAULT_TIMEOUT` of 30 seconds and ensuring that all `requests.get` calls in `src/indoscraping/scraper/news/cnbcindonesia.py` include this timeout parameter. Added a test case in `tests/test_cnbc_timeout.py` to verify the implementation.

---
*PR created automatically by Jules for task [18167996563253185033](https://jules.google.com/task/18167996563253185033) started by @nichsedge*